### PR TITLE
Fix gain from frontier selection method.

### DIFF
--- a/src/multirobotexploration/source/policies/Alysson2024.cpp
+++ b/src/multirobotexploration/source/policies/Alysson2024.cpp
@@ -267,18 +267,17 @@ int SelectFrontier(multirobotsimulations::Frontiers& rCentroids,
     double max = std::numeric_limits<double>::min();
     tf::Vector3 temp_c;
     int selected = 0;
-    double i_gain_heuristic = 0.0;
+    double gain_heuristic = 0.0;
     ROS_INFO("[Explorer] %ld available frontiers.", rCentroids.centroids.poses.size());
     for(size_t i = 0; i < rCentroids.centroids.poses.size(); ++i) {
         temp_c.setX(rCentroids.centroids.poses[i].position.x);
         temp_c.setY(rCentroids.centroids.poses[i].position.y);
-        i_gain_heuristic = rCentroids.utilities.data[i] - rCentroids.costs.data[i];
 
-        // compute cosine of the frontier here too!
+        gain_heuristic = ((double)rCentroids.utilities.data[i] / (double)rCentroids.costs.data[i]);
 
-        ROS_INFO("\t[%.2f %.2f] information gain: %.2f", temp_c.getX(), temp_c.getY(), i_gain_heuristic);
-        if(i_gain_heuristic > max) {
-            max = i_gain_heuristic;
+        ROS_INFO("\t[%.2f %.2f] gain: %.2f", temp_c.getX(), temp_c.getY(), gain_heuristic);
+        if(gain_heuristic > max) {
+            max = gain_heuristic;
             selected = i;
         }
     }


### PR DESCRIPTION
The old gain was a different between the utility and path length, which I've changed to a proportion.