### PR TITLE
 Added rendezvous spreading based on path cost to frontier

### DIFF
--- a/src/multirobotexploration/source/policies/RandomizedSocialWelfare.cpp
+++ b/src/multirobotexploration/source/policies/RandomizedSocialWelfare.cpp
@@ -182,9 +182,9 @@ void SetMotherbaseCallback(const std_msgs::String& rMsg) {
 
 int SelectFrontier(multirobotsimulations::Frontiers& rCentroids, 
                     tf::Vector3& rOutFrontierWorld) {
-    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_index].position.x);
-    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_index].position.y);
-    return rCentroids.highest_index;
+    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_gain_index].position.x);
+    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_gain_index].position.y);
+    return rCentroids.highest_gain_index;
 }
 
 int RoulettFrontier(multirobotsimulations::Frontiers& rCentroids, 

--- a/src/multirobotsimulations/msg/Frontiers.msg
+++ b/src/multirobotsimulations/msg/Frontiers.msg
@@ -2,5 +2,21 @@ geometry_msgs/PoseArray centroids
 std_msgs/Float64MultiArray utilities
 std_msgs/Float64MultiArray costs
 std_msgs/Float64MultiArray gains
-uint8 highest_index
-uint8 lowest_index
+
+uint8 highest_cost_index
+float32 highest_cost_value
+
+uint8 lowest_cost_index
+float32 lowest_cost_value
+
+uint8 highest_heuristic_index
+float32 highest_heuristic_value
+
+uint8 lowest_heuristic_index
+float32 lowest_heuristic_value
+
+uint8 highest_gain_index
+float32 highest_gain_value
+
+uint8 lowest_gain_index
+float32 lowest_gain_value


### PR DESCRIPTION
I've updated the sub-team rendezvous location update policy to assign the farthest frontier instead of a random one. This should maximize the average spread of the rendezvous locations if the robots are rational agents.