### PR TITLE
Frontier value and utility computation update and nearest goal policy

### DIFF
--- a/src/multirobotexploration/source/navigation/SubGoalNav.cpp
+++ b/src/multirobotexploration/source/navigation/SubGoalNav.cpp
@@ -188,7 +188,7 @@ void DepthFirstSearchFreePath(
     while(q.size() > 0) {
         current = q.front();
         q.pop();
-        sa::ComputePathWavefront(rCSpace, rAgentPos, current, rOutPath);
+        sa::ComputePath(rCSpace, rAgentPos, current, rOutPath);
         if(rOutPath.size() != 0) {
             rClosest = current;
             break;

--- a/src/multirobotexploration/source/policies/Alysson2024.cpp
+++ b/src/multirobotexploration/source/policies/Alysson2024.cpp
@@ -221,15 +221,15 @@ void ClustersCallback(const multirobotsimulations::Frontiers& rMsg) {
     CENTROIDS.centroids.header = rMsg.centroids.header;
     CENTROIDS.costs.data.assign(rMsg.costs.data.begin(), rMsg.costs.data.end());
     CENTROIDS.utilities.data.assign(rMsg.utilities.data.begin(), rMsg.utilities.data.end());
-    CENTROIDS.gains.data.assign(rMsg.gains.data.begin(), rMsg.gains.data.end());
+    CENTROIDS.values.data.assign(rMsg.values.data.begin(), rMsg.values.data.end());
     
     CENTROIDS.highest_cost_index = rMsg.highest_cost_index;
-    CENTROIDS.highest_heuristic_index = rMsg.highest_heuristic_index;
-    CENTROIDS.highest_gain_index = rMsg.highest_gain_index;
+    CENTROIDS.highest_value_index = rMsg.highest_value_index;
+    CENTROIDS.highest_utility_index = rMsg.highest_utility_index;
 
-    CENTROIDS.highest_cost_value = rMsg.highest_cost_value;
-    CENTROIDS.highest_heuristic_value = rMsg.highest_heuristic_value;
-    CENTROIDS.highest_gain_value = rMsg.highest_gain_value;
+    CENTROIDS.highest_cost = rMsg.highest_cost;
+    CENTROIDS.highest_value = rMsg.highest_value;
+    CENTROIDS.highest_utility = rMsg.highest_utility;
 
     if(CURRENT_STATE == state_waiting_centroids) 
         CURRENT_STATE = state_select_frontier;
@@ -271,12 +271,12 @@ void SetMotherbaseCallback(const std_msgs::String& rMsg) {
 
 int SelectFrontier(multirobotsimulations::Frontiers& rCentroids, 
                     tf::Vector3& rOutFrontierWorld) {
-    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_gain_index].position.x);
-    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_gain_index].position.y);
-    return rCentroids.highest_gain_index;
+    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_utility_index].position.x);
+    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_utility_index].position.y);
+    return rCentroids.highest_utility_index;
 }
 
-int RoulettFrontier(multirobotsimulations::Frontiers& rCentroids, 
+int RouletteFrontier(multirobotsimulations::Frontiers& rCentroids, 
                     tf::Vector3& rOutFrontierWorld) {
     std::uniform_int_distribution<int> distr(0, rCentroids.centroids.poses.size()-1); // define the range
     int selected = distr(gen); 
@@ -544,7 +544,7 @@ int main(int argc, char* argv[]) {
                     
                     if(CENTROIDS.centroids.poses.size() > 0) {
                         if(CheckNear(robots_in_comm, robot_id)) {
-                            RoulettFrontier(CENTROIDS, goal_frontier);
+                            RouletteFrontier(CENTROIDS, goal_frontier);
                             ROS_INFO("[Explorer] roulett frontier for randomized utility.");
                         } else {
                             SelectFrontier(CENTROIDS, goal_frontier);

--- a/src/multirobotexploration/source/policies/RandomizedSocialWelfare.cpp
+++ b/src/multirobotexploration/source/policies/RandomizedSocialWelfare.cpp
@@ -182,9 +182,9 @@ void SetMotherbaseCallback(const std_msgs::String& rMsg) {
 
 int SelectFrontier(multirobotsimulations::Frontiers& rCentroids, 
                     tf::Vector3& rOutFrontierWorld) {
-    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_gain_index].position.x);
-    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_gain_index].position.y);
-    return rCentroids.highest_gain_index;
+    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_utility_index].position.x);
+    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_utility_index].position.y);
+    return rCentroids.highest_utility_index;
 }
 
 int RoulettFrontier(multirobotsimulations::Frontiers& rCentroids, 

--- a/src/multirobotexploration/source/policies/Yamauchi1999.cpp
+++ b/src/multirobotexploration/source/policies/Yamauchi1999.cpp
@@ -180,28 +180,9 @@ void SetMotherbaseCallback(const std_msgs::String& rMsg) {
 int SelectFrontier(multirobotsimulations::Frontiers& rCentroids, 
                     tf::Vector3& rWorldPos, 
                     tf::Vector3& rOutFrontierWorld) {
-    if(rCentroids.centroids.poses.size() == 0) rCentroids.centroids.poses.end();
-    double max = std::numeric_limits<double>::min();
-    tf::Vector3 temp_c;
-    int selected = 0;
-    double i_gain_heuristic = 0.0;
-    ROS_INFO("[Explorer] %ld available frontiers.", rCentroids.centroids.poses.size());
-    for(size_t i = 0; i < rCentroids.centroids.poses.size(); ++i) {
-        temp_c.setX(rCentroids.centroids.poses[i].position.x);
-        temp_c.setY(rCentroids.centroids.poses[i].position.y);
-        i_gain_heuristic = rCentroids.utilities.data[i] - rCentroids.costs.data[i];
-
-        // compute cosine of the frontier here too!
-
-        ROS_INFO("\t[%.2f %.2f] information gain: %.2f", temp_c.getX(), temp_c.getY(), i_gain_heuristic);
-        if(i_gain_heuristic > max) {
-            max = i_gain_heuristic;
-            selected = i;
-        }
-    }
-    rOutFrontierWorld.setX(rCentroids.centroids.poses[selected].position.x);
-    rOutFrontierWorld.setY(rCentroids.centroids.poses[selected].position.y);
-    return selected;
+    rOutFrontierWorld.setX(rCentroids.centroids.poses[rCentroids.highest_utility_index].position.x);
+    rOutFrontierWorld.setY(rCentroids.centroids.poses[rCentroids.highest_utility_index].position.y);
+    return rCentroids.highest_utility_index;
 }
 
 void SetGoal(tf::Vector3& rGoal, ros::Publisher& rPublisher) {

--- a/src/multirobotsimulations/msg/Frontiers.msg
+++ b/src/multirobotsimulations/msg/Frontiers.msg
@@ -1,22 +1,22 @@
 geometry_msgs/PoseArray centroids
-std_msgs/Float64MultiArray utilities
 std_msgs/Float64MultiArray costs
-std_msgs/Float64MultiArray gains
+std_msgs/Float64MultiArray values
+std_msgs/Float64MultiArray utilities
 
 uint8 highest_cost_index
-float32 highest_cost_value
+float32 highest_cost
 
 uint8 lowest_cost_index
-float32 lowest_cost_value
+float32 lowest_cost
 
-uint8 highest_heuristic_index
-float32 highest_heuristic_value
+uint8 highest_value_index
+float32 highest_value
 
-uint8 lowest_heuristic_index
-float32 lowest_heuristic_value
+uint8 lowest_value_index
+float32 lowest_value
 
-uint8 highest_gain_index
-float32 highest_gain_value
+uint8 highest_utility_index
+float32 highest_utility
 
-uint8 lowest_gain_index
-float32 lowest_gain_value
+uint8 lowest_utility_index
+float32 lowest_utility


### PR DESCRIPTION
In this PR I've added the concept of using the uncovered area to compute frontier values.
Some authors prefer using more complex methods, however, in practice it is impossible to predict
what is to come. Consequently, authors, such as Burgard, mention that computing the area to be
uncovered given a sensor range is enough.

Previously, the sub-goal navigation was using a wavefront based method to find
the waypoint closest to the desired location. This is efficient, but not optimal
in terms of cost. I've update the algorithm for best path instead.