### PR TITLE
Tweak obstacle inflattion for local planner

### DIFF
--- a/src/multirobotexploration/launch/exploration_stack_bringup.launch
+++ b/src/multirobotexploration/launch/exploration_stack_bringup.launch
@@ -277,7 +277,7 @@
             <param name="enable_homotopy_class_planning" value="True"/>
             <param name="allow_init_with_backwards_motion" value="False"/>
             <param name="exact_arc_length" value="False"/>
-            <param name="inflation_dist" value="0.0"/>
+            <param name="inflation_dist" value="0.2"/>
             <param name="min_obstacle_dist" value="0.1"/>
             <param name="weight_kinematics_forward_drive" value="1.0"/>
         </node>


### PR DESCRIPTION
In this PR I've slightly increased the local planner inflation radius to avoid instability from polygon obstacles' edges.