### PR TITLE
Removed node handle from frontier node constructor and bug fix

### DIFF
--- a/src/multirobotexploration/CMakeLists.txt
+++ b/src/multirobotexploration/CMakeLists.txt
@@ -101,9 +101,6 @@ target_link_libraries(mrelocalplanner multirobotexploration ${catkin_LIBRARIES})
 ###############
 ## frontiers ##
 ###############
-add_executable(frontierdiscovery source/frontier/FrontierDiscovery.cpp)
-target_link_libraries(frontierdiscovery multirobotexploration ${catkin_LIBRARIES})
-
 add_executable(frontierdiscoverynode source/frontier/FrontierDiscoveryNode.cpp)
 target_link_libraries(frontierdiscoverynode multirobotexploration ${catkin_LIBRARIES})
 

--- a/src/multirobotexploration/include/nodes/FrontierDiscoveryNode.h
+++ b/src/multirobotexploration/include/nodes/FrontierDiscoveryNode.h
@@ -79,7 +79,7 @@ typedef enum{
  */
 class FrontierDiscoveryNode {
     public:
-        FrontierDiscoveryNode(ros::NodeHandle& nodeHandle);
+        FrontierDiscoveryNode();
         ~FrontierDiscoveryNode();
 
     private:


### PR DESCRIPTION
Removed old frontier node from CMakeLists. Furthermore, also removed the node handle parameter to have a simpler signature.